### PR TITLE
API-4608: Fix endpoint paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This job posts the repository to ECR, from where you can clone it and run locall
 ## Example Run
 
 ```sh
-curl -H "Content-Type: application/json" -X POST -d '{"claim_text":["Ringing in my ear", "cancer due to agent orange", "p.t.s.d from gulf war", "recurring nightmares", "skin condition because of homelessness"]}' localhost:8000/benefits-claims-attributes/
+curl -H "Content-Type: application/json" -X POST -d '{"claim_text":["Ringing in my ear", "cancer due to agent orange", "p.t.s.d from gulf war", "recurring nightmares", "skin condition because of homelessness"]}' http://localhost:8000/services/claims-attributes/v1/
 ```
 
 The response should looks like this:

--- a/src/api_service/app/main.py
+++ b/src/api_service/app/main.py
@@ -13,13 +13,17 @@ app = FastAPI(
     openapi_url=f"/{api_prefix}/{version}/docs/openapi.json",
 )
 
-
 def custom_openapi():
+    documented_routes = []
+    for route in app.routes:
+        if 'healthcheck' not in route.path:
+          documented_routes.append(route)
+
     openapi_schema = get_openapi(
         title="Claims Attributes API",
         version="1.0.0",
         description=Path(files("app.data").joinpath("summary.md")).read_text(),
-        routes=[app.routes[0], app.routes[1], app.routes[2], app.routes[3], app.routes[5]]
+        routes=documented_routes
     )
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/src/api_service/app/main.py
+++ b/src/api_service/app/main.py
@@ -19,7 +19,7 @@ def custom_openapi():
         title="Claims Attributes API",
         version="1.0.0",
         description=Path(files("app.data").joinpath("summary.md")).read_text(),
-        routes=app.routes,
+        routes=[app.routes[0], app.routes[1], app.routes[2], app.routes[3], app.routes[5]]
     )
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/src/api_service/app/main.py
+++ b/src/api_service/app/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from importlib_resources import files
 
 # All API calls have this prefix in order to avoid Load Balancer conflicts
-api_prefix = "benefits-claims-attributes"
+api_prefix = "services/claims-attributes"
 version = "v1"
 
 app = FastAPI(


### PR DESCRIPTION
https://vajira.max.gov/browse/API-4608

Paths should match kong paths now.
Healthcheck endpoint should be hidden from documentation.

Note: I based all this off of the json returned from http://localhost:8000/services/claims-attributes/v1/docs/openapi.json because i couldnt get my local setup configured properly to present this information within the developer-portal views.