### PR TITLE
API-4608: Revert endpoints to previous structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This job posts the repository to ECR, from where you can clone it and run locall
 ## Example Run
 
 ```sh
-curl -H "Content-Type: application/json" -X POST -d '{"claim_text":["Ringing in my ear", "cancer due to agent orange", "p.t.s.d from gulf war", "recurring nightmares", "skin condition because of homelessness"]}' http://localhost:8000/services/claims-attributes/v1/
+curl -H "Content-Type: application/json" -X POST -d '{"claim_text":["Ringing in my ear", "cancer due to agent orange", "p.t.s.d from gulf war", "recurring nightmares", "skin condition because of homelessness"]}' http://localhost:8000/benefits-claims-attributes/v1/
 ```
 
 The response should looks like this:

--- a/src/api_service/app/main.py
+++ b/src/api_service/app/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from importlib_resources import files
 
 # All API calls have this prefix in order to avoid Load Balancer conflicts
-api_prefix = "services/claims-attributes"
+api_prefix = "benefits-claims-attributes"
 version = "v1"
 
 app = FastAPI(

--- a/src/api_service/tests/test_api.py
+++ b/src/api_service/tests/test_api.py
@@ -58,12 +58,12 @@ def mock_responses(requests_mock):
 
 @pytest.mark.smoke
 def test_healthcheck(client):
-    response = client.get("/services/claims-attributes/v1/healthcheck")
+    response = client.get("/benefits-claims-attributes/v1/healthcheck")
     assert response.status_code == 200
     assert response.json() == "App OK"
 
 def test_docs(client):
-    response = client.get("/services/claims-attributes/v1/docs/openapi.json")
+    response = client.get("/benefits-claims-attributes/v1/docs/openapi.json")
     assert response.status_code == 200
     output = response.json()
     assert output["info"]["title"] == "Claims Attributes API"
@@ -80,7 +80,7 @@ def global_config():
                 "skin condition because of homelessness",
             ]
         },
-        "predict_uri": "/services/claims-attributes/v1/",
+        "predict_uri": "/benefits-claims-attributes/v1/",
     }
 
 def test_predict_working(client, global_config, requests_mock):


### PR DESCRIPTION
https://vajira.max.gov/browse/API-4608

Discussion has been had and apparently these should stay the way they were because the tool Quokka is about to deploy should fix the urls in documentation:
https://lighthouseva.slack.com/archives/CT0G8GMS7/p1612287874014100?thread_ts=1612224015.011400&cid=CT0G8GMS7