### PR TITLE
API-4607 Add examples to request docs

### DIFF
--- a/src/api_service/app/main.py
+++ b/src/api_service/app/main.py
@@ -8,9 +8,17 @@ from importlib_resources import files
 api_prefix = "benefits-claims-attributes"
 version = "v1"
 
+tags_metadata = [
+    {
+        "name": "Claims Attributes",
+        "description": "Predict attributes for a claim"
+    }
+]
+
 app = FastAPI(
     docs_url=f"/{api_prefix}/{version}/docs",
     openapi_url=f"/{api_prefix}/{version}/docs/openapi.json",
+    openapi_tags=tags_metadata
 )
 
 def custom_openapi():

--- a/src/api_service/app/main.py
+++ b/src/api_service/app/main.py
@@ -36,7 +36,6 @@ def custom_openapi():
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 
-
 global_router = APIRouter()
 global_router.include_router(healthcheck.router)
 global_router.include_router(predict.router)

--- a/src/api_service/app/routers/predict.py
+++ b/src/api_service/app/routers/predict.py
@@ -61,7 +61,7 @@ class Predictor:
         return parsed_data
 
 
-@router.post("/", response_model=Prediction)
+@router.post("/", response_model=Prediction, tags=["Claims Attributes"])
 async def get_prediction(claim_input: ClaimInput):
     """
     This takes an array of user's claimed disabilities (`claims_text`) and

--- a/src/api_service/app/routers/predict.py
+++ b/src/api_service/app/routers/predict.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Security
 from typing import List
 from pydantic import BaseModel
 import requests
@@ -59,7 +59,6 @@ class Predictor:
             raise
         parsed_data = model.parse_obj(response.json())
         return parsed_data
-
 
 @router.post("/", response_model=Prediction, tags=["Claims Attributes"])
 async def get_prediction(claim_input: ClaimInput):

--- a/src/shared/caapi_shared/schemas.py
+++ b/src/shared/caapi_shared/schemas.py
@@ -12,6 +12,13 @@ class ClaimInput(BaseModel):
         description="""
         An array of strings representing claimed disabilities. These will be classified on a per-disability basis in the output.
         """,
+        example= [
+            "Ringing in my ear",
+            "cancer due to agent orange",
+            "p.t.s.d from gulf war",
+            "recurring nightmares",
+            "skin condition because of homelessness",
+        ]
     )
 
 


### PR DESCRIPTION
I haven't been able to verify what this would look like in the actual lighthouse documentation, but here's what it looks like in the swagger generated docs currently:

![Screen Shot 2021-02-02 at 8 00 57 PM](https://user-images.githubusercontent.com/13280995/106687785-78212200-6592-11eb-8601-ec01e1339a3f.png)

I'm not sure if this has everything needed for the curl generator or not, definitely want to figure out how to verify this locally, if possible.